### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigquerymigration",
     "name_pretty": "Google BigQuery Migration",
     "product_documentation": "https://cloud.google.com/bigquery/docs/reference/migration/",
-    "client_documentation": "https://googleapis.dev/python/bigquerymigration/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerymigration/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
     "release_level": "alpha",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python client for `Google Cloud Bigquery Migration API`_.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-migration.svg
    :target: https://pypi.org/project/google-cloud-bigquery-migration/
 .. _Google Cloud Bigquery Migration API: https://cloud.google.com/bigquery/docs/reference/migration/
-.. _Client Library Documentation: https://googleapis.dev/python/bigquerymigration/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerymigration/latest
 .. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/migration/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.